### PR TITLE
Move to overrides that can be composed using `composeExtensions`

### DIFF
--- a/consumer-data-au-api-types/nix/consumer-data-au-api-types-overrides.nix
+++ b/consumer-data-au-api-types/nix/consumer-data-au-api-types-overrides.nix
@@ -1,0 +1,21 @@
+pkgs: self: super:
+let
+  upstreamSources = {
+    servant-waargonaut = (import ./servant-waargonaut.nix) {nixpkgs = pkgs;};
+  };
+
+  upstreamOverrides = {
+    servant-waargonaut = (import "${upstreamSources.servant-waargonaut}/servant-waargonaut-overrides.nix");
+  };
+
+  obOverrides = pkgs: (self: super: {
+    servant-waargonaut = self.callPackage (import "${upstreamSources.servant-waargonaut}/servant-waargonaut.nix") {};
+  });
+
+  composedOverrides =
+    pkgs.lib.foldr
+      (x: acc: pkgs.lib.composeExtensions acc (x { inherit pkgs; }))
+      (_: _: {})
+      (builtins.attrValues upstreamOverrides ++ [obOverrides]);
+in
+  composedOverrides self super

--- a/consumer-data-au-api-types/nix/haskellPackages.nix
+++ b/consumer-data-au-api-types/nix/haskellPackages.nix
@@ -7,23 +7,12 @@ let
     then pkgs.haskellPackages
     else pkgs.haskell.packages.${compiler};
 
-  upstreamSources = {
-    servant-waargonaut = (import ./servant-waargonaut.nix) { inherit nixpkgs; };
-  };
-  
-  upstreamOverrides = {
-    servant-waargonaut = (import "${upstreamSources.servant-waargonaut}/servant-waargonaut-overrides.nix");
-  };
-
-  obOverrides = pkgs: (self: super: {
-    servant-waargonaut = self.callPackage (import "${upstreamSources.servant-waargonaut}/servant-waargonaut.nix") {};
-  });
+  obOverrides = import ./consumer-data-au-api-types-overrides.nix pkgs;
 
   obHaskellPackages = haskellPackages.override (old: {
-    overrides = pkgs.lib.foldr 
-      (x: acc: pkgs.lib.composeExtensions acc (x { inherit pkgs; }))
-      (old.overrides or (_: _: {}))
-      [upstreamOverrides.servant-waargonaut obOverrides];
+    overrides = pkgs.lib.composeExtensions
+      (old.overrides or (_:_: {}))
+      obOverrides;
   });
 in
   obHaskellPackages

--- a/consumer-data-au-api-types/nix/servant-waargonaut.nix
+++ b/consumer-data-au-api-types/nix/servant-waargonaut.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import ./nixpkgs.nix }:
+{ nixpkgs ? import ../../nixpkgs.nix }:
 nixpkgs.pkgs.fetchgit {
   inherit (nixpkgs.pkgs.lib.importJSON ./servant-waargonaut.json) url rev sha256;
 }

--- a/consumer-data-au-api-types/shell.nix
+++ b/consumer-data-au-api-types/shell.nix
@@ -9,8 +9,8 @@ let
   drv = (import ./. {});
 
   haskellPackages = import ./nix/haskellPackages.nix {inherit nixpkgs compiler;};
-  hie-tools = if !hie then [] else (with pkgs.haskellPackages; 
-    [ Cabal_2_4_0_1 apply-refact hsimport hasktags hlint hoogle brittany ]); 
+  hie-tools = if !hie then [] else (with pkgs.haskellPackages;
+    [ Cabal_2_4_0_1 apply-refact hsimport hasktags hlint hoogle brittany ]);
 
   shellDrv = pkgs.haskell.lib.overrideCabal drv (drv': {
     buildDepends =


### PR DESCRIPTION
This will let us compose our overrides as we introduce other packages that
depend on this one and may then have their own overrides.