### PR TITLE
Accept optional keys when they are absent

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,9 +10,9 @@ haddock-css: ../haddock.css
 source-repository-package
   type: git
   location: https://github.com/qfpl/servant-waargonaut.git
-  tag: f2c530230cb9a0595f88900e41168ba9b0af55d4
+  tag: 89723f630cb3cc4d2dd7544b8e55cba9b9354bde
 
 source-repository-package
   type: git
   location: https://github.com/qfpl/waargonaut.git
-  tag: d9759df1b1eaced87efab82bb9f92d7ee3c14024
+  tag: e94dc7c8632a2fbb5605efb21a1d9b4492457da9

--- a/consumer-data-au-api-types/consumer-data-au-api-types.cabal
+++ b/consumer-data-au-api-types/consumer-data-au-api-types.cabal
@@ -22,6 +22,7 @@ library
                      , Data.GADT.Aeson.TH
                      , Data.GADT.Tag.TH
                      , Data.Time.Waargonaut
+                     , Waargonaut.Helpers
                      , Web.ConsumerData.Au.Api.Types
                      , Web.ConsumerData.Au.Api.Types.Auth.AuthorisationRequest
                      , Web.ConsumerData.Au.Api.Types.Auth.Common
@@ -118,7 +119,7 @@ library
                      , time >= 1.8 && < 1.10
                      , transformers == 0.5.*
                      , unordered-containers == 0.2.*
-                     , waargonaut == 0.4.*
+                     , waargonaut == 0.4.2.*
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -Werror
@@ -163,7 +164,7 @@ test-suite tasty
                      , time >= 1.8 && < 1.10
                      , transformers == 0.5.*
                      , wai == 3.2.*
-                     , waargonaut == 0.4.*
+                     , waargonaut == 0.4.2.*
                      , warp == 3.2.*
   other-modules:
                        Country.Gens

--- a/consumer-data-au-api-types/nix/servant-waargonaut.json
+++ b/consumer-data-au-api-types/nix/servant-waargonaut.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/servant-waargonaut",
-  "rev": "f2c530230cb9a0595f88900e41168ba9b0af55d4",
-  "date": "2018-11-26T14:46:14+10:00",
-  "sha256": "1s2laza7kc83i9ngn7rywjbb05pwk728ck96pzjvwz2fhzf5a96f",
+  "rev": "89723f630cb3cc4d2dd7544b8e55cba9b9354bde",
+  "date": "2018-11-29T11:57:10+10:00",
+  "sha256": "1zzmm5zljl45051xpbaklsrbrn7l9rp5igb0n4caqvipi909dgzg",
   "fetchSubmodules": false
 }

--- a/consumer-data-au-api-types/src/Waargonaut/Helpers.hs
+++ b/consumer-data-au-api-types/src/Waargonaut/Helpers.hs
@@ -1,0 +1,19 @@
+module Waargonaut.Helpers where
+
+import Control.Monad (join)
+import Data.Text (Text)
+
+import Waargonaut.Decode (Decoder, DecodeResult, JCurs)
+import Waargonaut.Encode (Encoder')
+import Waargonaut.Types (Json, MapLikeObj)
+import qualified Waargonaut.Decode as D
+import qualified Waargonaut.Encode as E
+
+fromKeyOptional' :: Monad f => Text -> Decoder f a -> JCurs -> DecodeResult f (Maybe a)
+fromKeyOptional' t d = fmap join . D.fromKeyOptional t (D.maybeOrNull d)
+
+atKeyOptional' :: Monad f => Text -> Decoder f a -> Decoder f (Maybe a)
+atKeyOptional' t d = join <$> D.atKeyOptional t (D.maybeOrNull d)
+
+maybeOrAbsentE :: (Monoid ws, Semigroup ws) => Text -> Encoder' a -> Maybe a -> MapLikeObj ws Json -> MapLikeObj ws Json
+maybeOrAbsentE t e = maybe id (E.atKey' t e)

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/Common/Identified.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/Common/Identified.hs
@@ -13,6 +13,7 @@ import qualified Waargonaut.Decode                   as D
 import           Waargonaut.Encode                   (Encoder)
 import qualified Waargonaut.Encode                   as E
 
+import           Waargonaut.Helpers                  (atKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.Common.Accounts (AccountId, accountIdDecoder, accountIdEncoder)
 
 data Identified a = Identified
@@ -23,17 +24,16 @@ data Identified a = Identified
   } deriving (Generic, Show, Eq, Functor, Foldable, Traversable)
 
 identifiedDecoder :: Monad f => Text -> Decoder f a -> Decoder f (Identified a)
-identifiedDecoder key payloadDecoder = D.withCursor $ \c -> do
-  o <- D.down c
-  accId <- D.fromKey "accountId" accountIdDecoder o
-  disp <- D.fromKey "displayName" D.text o
-  nick <- D.fromKey "nickname" (D.maybeOrNull D.text) o
-  p <- D.fromKey key payloadDecoder o
-  pure $ Identified accId disp nick p
+identifiedDecoder key payloadDecoder =
+  Identified
+    <$> D.atKey "accountId" accountIdDecoder
+    <*> D.atKey "displayName" D.text
+    <*> atKeyOptional' "nickname" D.text
+    <*> D.atKey key payloadDecoder
 
 identifiedEncoder :: Applicative f => Text -> E.Encoder' a -> Encoder f (Identified a)
 identifiedEncoder key enc = E.mapLikeObj $ \(Identified accId disp nick p) ->
   E.atKey' "accountId" accountIdEncoder accId .
   E.atKey' "displayName" E.text disp .
-  E.atKey' "nickname" (E.maybeOrNull E.text) nick .
+  maybeOrAbsentE "nickname" E.text nick .
   E.atKey' key enc p

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/Common/ProductDetail.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/Common/ProductDetail.hs
@@ -17,6 +17,7 @@ import           Waargonaut.Encode          (Encoder)
 import qualified Waargonaut.Encode          as E
 import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 
+import           Waargonaut.Helpers         (atKeyOptional', fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Response
     (uriDecoder, uriEncoder)
 import Web.ConsumerData.Au.Api.Types.Tag
@@ -58,14 +59,14 @@ productDetailDecoder = D.withCursor $ \c -> do
   o <- D.down c
   ProductDetail
     <$> D.focus (D.maybeOrNull productDecoder) o
-    <*> D.fromKey "bundles" (D.maybeOrNull productBundlesDecoder) o
-    <*> D.fromKey "features" (D.maybeOrNull productFeaturesDecoder) o
-    <*> D.fromKey "constraints" (D.maybeOrNull productConstraintsDecoder) o
-    <*> D.fromKey "eligibility" (D.maybeOrNull productEligibilitiesDecoder) o
-    <*> D.fromKey "fees" (D.maybeOrNull productFeesDecoder) o
-    <*> D.fromKey "depositRates" (D.maybeOrNull productDepositRatesDecoder) o
-    <*> D.fromKey "lendingRates" (D.maybeOrNull productLendingRatesDecoder) o
-    <*> D.fromKey "repaymentType" (D.maybeOrNull productRepaymentTypeDecoder) o
+    <*> fromKeyOptional' "bundles" productBundlesDecoder o
+    <*> fromKeyOptional' "features" productFeaturesDecoder o
+    <*> fromKeyOptional' "constraints" productConstraintsDecoder o
+    <*> fromKeyOptional' "eligibility" productEligibilitiesDecoder o
+    <*> fromKeyOptional' "fees" productFeesDecoder o
+    <*> fromKeyOptional' "depositRates" productDepositRatesDecoder o
+    <*> fromKeyOptional' "lendingRates" productLendingRatesDecoder o
+    <*> fromKeyOptional' "repaymentType" productRepaymentTypeDecoder o
 
 instance JsonDecode OB ProductDetail where
   mkDecoder = tagOb productDetailDecoder
@@ -76,14 +77,14 @@ instance JsonEncode OB ProductDetail where
 productDetailEncoder :: Applicative f => Encoder f ProductDetail
 productDetailEncoder = E.mapLikeObj $ \pd ->
   maybe id productFields (_productDetailProduct pd) .
-  E.atKey' "bundles" (E.maybeOrNull productBundlesEncoder) (_productDetailBundles pd) .
-  E.atKey' "features" (E.maybeOrNull productFeaturesEncoder) (_productDetailFeatures pd) .
-  E.atKey' "constraints" (E.maybeOrNull productConstraintsEncoder) (_productDetailConstraints pd) .
-  E.atKey' "eligibility" (E.maybeOrNull productEligibilitiesEncoder) (_productDetailEligibility pd) .
-  E.atKey' "fees" (E.maybeOrNull productFeesEncoder) (_productDetailFees pd) .
-  E.atKey' "depositRates" (E.maybeOrNull productDepositRatesEncoder) (_productDetailDepositRates pd) .
-  E.atKey' "lendingRates" (E.maybeOrNull productLendingRatesEncoder) (_productDetailLendingRates pd) .
-  E.atKey' "repaymentType" (E.maybeOrNull productRepaymentTypeEncoder) (_productDetailRepaymentType pd)
+  maybeOrAbsentE "bundles" productBundlesEncoder (_productDetailBundles pd) .
+  maybeOrAbsentE "features" productFeaturesEncoder (_productDetailFeatures pd) .
+  maybeOrAbsentE "constraints" productConstraintsEncoder (_productDetailConstraints pd) .
+  maybeOrAbsentE "eligibility" productEligibilitiesEncoder (_productDetailEligibility pd) .
+  maybeOrAbsentE "fees" productFeesEncoder (_productDetailFees pd) .
+  maybeOrAbsentE "depositRates" productDepositRatesEncoder (_productDetailDepositRates pd) .
+  maybeOrAbsentE "lendingRates" productLendingRatesEncoder (_productDetailLendingRates pd) .
+  maybeOrAbsentE "repaymentType" productRepaymentTypeEncoder (_productDetailRepaymentType pd)
 
 
 newtype ProductBundles =
@@ -111,13 +112,12 @@ data ProductBundle = ProductBundle
   } deriving (Eq, Show)
 
 productBundleDecoder :: Monad f => Decoder f ProductBundle
-productBundleDecoder = D.withCursor $ \c -> do
-  o <- D.down c
+productBundleDecoder =
   ProductBundle
-    <$> D.fromKey "name" D.text o
-    <*> D.fromKey "description" D.text o
-    <*> D.fromKey "applicationUri" (D.maybeOrNull uriDecoder) o
-    <*> D.fromKey "productIds" (D.list D.text) o
+    <$> D.atKey "name" D.text
+    <*> D.atKey "description" D.text
+    <*> atKeyOptional' "applicationUri" uriDecoder
+    <*> D.atKey "productIds" (D.list D.text)
 
 instance JsonDecode OB ProductBundle where
   mkDecoder = tagOb productBundleDecoder
@@ -126,7 +126,7 @@ productBundleEncoder :: Applicative f => Encoder f ProductBundle
 productBundleEncoder = E.mapLikeObj $ \p ->
   E.atKey' "name" E.text (_productBundleName p) .
   E.atKey' "description" E.text (_productBundleDescription p) .
-  E.atKey' "applicationUri" (E.maybeOrNull uriEncoder) (_productBundleAdditionalInfoUri p) .
+  maybeOrAbsentE "applicationUri" uriEncoder (_productBundleAdditionalInfoUri p) .
   E.atKey' "productIds" (E.list E.text) (_productBundleProductIds p)
 
 instance JsonEncode OB ProductBundle where

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/DepositRate.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/DepositRate.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Data.CommonFieldTypes
@@ -67,8 +68,8 @@ accountDepositRateDecoder = D.withCursor $ \c -> do
   AccountDepositRate
     <$> D.focus accountDepositRateTypeDecoder o
     <*> D.fromKey "rate" rateStringDecoder o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
 
 instance JsonDecode OB AccountDepositRate where
   mkDecoder = tagOb accountDepositRateDecoder
@@ -77,8 +78,8 @@ accountDepositRateEncoder :: Applicative f => Encoder f AccountDepositRate
 accountDepositRateEncoder = E.mapLikeObj $ \p ->
   accountDepositRateTypeFields (_accountDepositRateDepositRateType p) .
   E.atKey' "rate" rateStringEncoder (_accountDepositRateRate p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_accountDepositRateAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_accountDepositRateAdditionalInfoUri p)
+  maybeOrAbsentE "additionalInfo" E.text (_accountDepositRateAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_accountDepositRateAdditionalInfoUri p)
 
 instance JsonEncode OB AccountDepositRate where
   mkEncoder = tagOb accountDepositRateEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/Fee.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/Fee.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.Account.Discount
     (AccountDiscounts, accountDiscountsDecoder, accountDiscountsEncoder)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
@@ -77,13 +78,13 @@ accountFeeDecoder = D.withCursor $ \c -> do
   AccountFee
     <$> D.fromKey "name" D.text o
     <*> D.focus accountFeeTypeDecoder o
-    <*> D.fromKey "amount" (D.maybeOrNull amountStringDecoder) o
-    <*> D.fromKey "balanceRate" (D.maybeOrNull rateStringDecoder) o
-    <*> D.fromKey "transactionRate" (D.maybeOrNull rateStringDecoder) o
-    <*> D.fromKey "currency" (D.maybeOrNull currencyStringDecoder) o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
-    <*> D.fromKey "discounts" (D.maybeOrNull accountDiscountsDecoder) o
+    <*> fromKeyOptional' "amount" amountStringDecoder o
+    <*> fromKeyOptional' "balanceRate" rateStringDecoder o
+    <*> fromKeyOptional' "transactionRate" rateStringDecoder o
+    <*> fromKeyOptional' "currency" currencyStringDecoder o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
+    <*> fromKeyOptional' "discounts" accountDiscountsDecoder o
 
 instance JsonDecode OB AccountFee where
   mkDecoder = tagOb accountFeeDecoder
@@ -92,13 +93,13 @@ accountFeeEncoder :: Applicative f => Encoder f AccountFee
 accountFeeEncoder = E.mapLikeObj $ \p ->
   E.atKey' "name" E.text (_accountFeeName p) .
   accountFeeTypeFields (_accountFeeFeeType p) .
-  E.atKey' "amount" (E.maybeOrNull amountStringEncoder) (_accountFeeAmount p) .
-  E.atKey' "balanceRate" (E.maybeOrNull rateStringEncoder) (_accountFeeBalanceRate p) .
-  E.atKey' "transactionRate" (E.maybeOrNull rateStringEncoder) (_accountFeeTransactionRate p) .
-  E.atKey' "currency" (E.maybeOrNull currencyStringEncoder) (_accountFeeCurrency p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_accountFeeAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_accountFeeAdditionalInfoUri p) .
-  E.atKey' "discounts" (E.maybeOrNull accountDiscountsEncoder) (_accountFeeDiscounts p)
+  maybeOrAbsentE "amount" amountStringEncoder (_accountFeeAmount p) .
+  maybeOrAbsentE "balanceRate" rateStringEncoder (_accountFeeBalanceRate p) .
+  maybeOrAbsentE "transactionRate" rateStringEncoder (_accountFeeTransactionRate p) .
+  maybeOrAbsentE "currency" currencyStringEncoder (_accountFeeCurrency p) .
+  maybeOrAbsentE "additionalInfo" E.text (_accountFeeAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_accountFeeAdditionalInfoUri p) .
+  maybeOrAbsentE "discounts" accountDiscountsEncoder (_accountFeeDiscounts p)
 
 instance JsonEncode OB AccountFee where
   mkEncoder = tagOb accountFeeEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/LendingRate.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Account/LendingRate.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Data.CommonFieldTypes
@@ -67,8 +68,8 @@ accountLendingRateDecoder = D.withCursor $ \c -> do
   AccountLendingRate
     <$> D.focus accountLendingRateTypeDecoder o
     <*> D.fromKey "rate" rateStringDecoder o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
 
 instance JsonDecode OB AccountLendingRate where
   mkDecoder = tagOb accountLendingRateDecoder
@@ -77,8 +78,8 @@ accountLendingRateEncoder :: Applicative f => Encoder f AccountLendingRate
 accountLendingRateEncoder = E.mapLikeObj $ \p ->
   accountLendingRateTypeFields (_accountLendingRateLendingRateType p) .
   E.atKey' "rate" rateStringEncoder (_accountLendingRateRate p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_accountLendingRateAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_accountLendingRateAdditionalInfoUri p)
+  maybeOrAbsentE "additionalInfo" E.text (_accountLendingRateAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_accountLendingRateAdditionalInfoUri p)
 
 instance JsonEncode OB AccountLendingRate where
   mkEncoder = tagOb accountLendingRateEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/DepositRate.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/DepositRate.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Data.CommonFieldTypes
@@ -67,8 +68,8 @@ productDepositRateDecoder = D.withCursor $ \c -> do
   ProductDepositRate
     <$> D.focus productDepositRateTypeDecoder o
     <*> D.fromKey "rate" rateStringDecoder o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
 
 instance JsonDecode OB ProductDepositRate where
   mkDecoder = tagOb productDepositRateDecoder
@@ -77,8 +78,8 @@ productDepositRateEncoder :: Applicative f => Encoder f ProductDepositRate
 productDepositRateEncoder = E.mapLikeObj $ \p ->
   productDepositRateTypeFields (_productDepositRateDepositRateType p) .
   E.atKey' "rate" rateStringEncoder (_productDepositRateRate p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_productDepositRateAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_productDepositRateAdditionalInfoUri p)
+  maybeOrAbsentE "additionalInfo" E.text (_productDepositRateAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_productDepositRateAdditionalInfoUri p)
 
 instance JsonEncode OB ProductDepositRate where
   mkEncoder = tagOb productDepositRateEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/Eligibility.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/Eligibility.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Data.CommonFieldTypes
@@ -64,8 +65,8 @@ productEligibilityDecoder = D.withCursor $ \c -> do
   ProductEligibility
     <$> D.fromKey "description" D.text o
     <*> D.focus productEligibilityTypeDecoder o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
 
 instance JsonDecode OB ProductEligibility where
   mkDecoder = tagOb productEligibilityDecoder
@@ -74,8 +75,8 @@ productEligibilityEncoder :: Applicative f => Encoder f ProductEligibility
 productEligibilityEncoder = E.mapLikeObj $ \p ->
   E.atKey' "description" E.text (_productEligibilityDescription p) .
   productEligibilityTypeFields (_productEligibilityEligibilityType p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_productEligibilityAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_productEligibilityAdditionalInfoUri p)
+  maybeOrAbsentE "additionalInfo" E.text (_productEligibilityAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_productEligibilityAdditionalInfoUri p)
 
 instance JsonEncode OB ProductEligibility where
   mkEncoder = tagOb productEligibilityEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/Fee.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/Fee.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.Product.Discount
@@ -77,13 +78,13 @@ productFeeDecoder = D.withCursor $ \c -> do
   ProductFee
     <$> D.fromKey "name" D.text o
     <*> D.focus productFeeTypeDecoder o
-    <*> D.fromKey "amount" (D.maybeOrNull amountStringDecoder) o
-    <*> D.fromKey "balanceRate" (D.maybeOrNull rateStringDecoder) o
-    <*> D.fromKey "transactionRate" (D.maybeOrNull rateStringDecoder) o
-    <*> D.fromKey "currency" (D.maybeOrNull currencyStringDecoder) o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
-    <*> D.fromKey "discounts" (D.maybeOrNull productDiscountsDecoder) o
+    <*> fromKeyOptional' "amount" amountStringDecoder o
+    <*> fromKeyOptional' "balanceRate" rateStringDecoder o
+    <*> fromKeyOptional' "transactionRate" rateStringDecoder o
+    <*> fromKeyOptional' "currency" currencyStringDecoder o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
+    <*> fromKeyOptional' "discounts" productDiscountsDecoder o
 
 instance JsonDecode OB ProductFee where
   mkDecoder = tagOb productFeeDecoder
@@ -92,13 +93,13 @@ productFeeEncoder :: Applicative f => Encoder f ProductFee
 productFeeEncoder = E.mapLikeObj $ \p ->
   E.atKey' "name" E.text (_productFeeName p) .
   productFeeTypeFields (_productFeeFeeType p) .
-  E.atKey' "amount" (E.maybeOrNull amountStringEncoder) (_productFeeAmount p) .
-  E.atKey' "balanceRate" (E.maybeOrNull rateStringEncoder) (_productFeeBalanceRate p) .
-  E.atKey' "transactionRate" (E.maybeOrNull rateStringEncoder) (_productFeeTransactionRate p) .
-  E.atKey' "currency" (E.maybeOrNull currencyStringEncoder) (_productFeeCurrency p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_productFeeAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_productFeeAdditionalInfoUri p) .
-  E.atKey' "discounts" (E.maybeOrNull productDiscountsEncoder) (_productFeeDiscounts p)
+  maybeOrAbsentE "amount" amountStringEncoder (_productFeeAmount p) .
+  maybeOrAbsentE "balanceRate" rateStringEncoder (_productFeeBalanceRate p) .
+  maybeOrAbsentE "transactionRate" rateStringEncoder (_productFeeTransactionRate p) .
+  maybeOrAbsentE "currency" currencyStringEncoder (_productFeeCurrency p) .
+  maybeOrAbsentE "additionalInfo" E.text (_productFeeAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_productFeeAdditionalInfoUri p) .
+  maybeOrAbsentE "discounts" productDiscountsEncoder (_productFeeDiscounts p)
 
 instance JsonEncode OB ProductFee where
   mkEncoder = tagOb productFeeEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/LendingRate.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Banking/ProductAccountComponents/Product/LendingRate.hs
@@ -22,6 +22,7 @@ import           Waargonaut.Generic         (JsonDecode (..), JsonEncode (..))
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json      (Json)
 
+import           Waargonaut.Helpers         (fromKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Banking.ProductAccountComponents.AdditionalValue
     (additionalValueDecoder)
 import Web.ConsumerData.Au.Api.Types.Data.CommonFieldTypes
@@ -67,8 +68,8 @@ productLendingRateDecoder = D.withCursor $ \c -> do
   ProductLendingRate
     <$> D.focus productLendingRateTypeDecoder o
     <*> D.fromKey "rate" rateStringDecoder o
-    <*> D.fromKey "additionalInfo" (D.maybeOrNull D.text) o
-    <*> D.fromKey "additionalInfoUri" (D.maybeOrNull uriDecoder) o
+    <*> fromKeyOptional' "additionalInfo" D.text o
+    <*> fromKeyOptional' "additionalInfoUri" uriDecoder o
 
 instance JsonDecode OB ProductLendingRate where
   mkDecoder = tagOb productLendingRateDecoder
@@ -77,8 +78,8 @@ productLendingRateEncoder :: Applicative f => Encoder f ProductLendingRate
 productLendingRateEncoder = E.mapLikeObj $ \p ->
   productLendingRateTypeFields (_productLendingRateLendingRateType p) .
   E.atKey' "rate" rateStringEncoder (_productLendingRateRate p) .
-  E.atKey' "additionalInfo" (E.maybeOrNull E.text) (_productLendingRateAdditionalInfo p) .
-  E.atKey' "additionalInfoUri" (E.maybeOrNull uriEncoder) (_productLendingRateAdditionalInfoUri p)
+  maybeOrAbsentE "additionalInfo" E.text (_productLendingRateAdditionalInfo p) .
+  maybeOrAbsentE "additionalInfoUri" uriEncoder (_productLendingRateAdditionalInfoUri p)
 
 instance JsonEncode OB ProductLendingRate where
   mkEncoder = tagOb productLendingRateEncoder

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Common/Customer/Data/Organisation.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Common/Customer/Data/Organisation.hs
@@ -23,6 +23,7 @@ import           Waargonaut.Encode       (Encoder)
 import qualified Waargonaut.Encode       as E
 import           Waargonaut.Types.JObject   (MapLikeObj)
 import           Waargonaut.Types.Json   (Json)
+import           Waargonaut.Helpers      (atKeyOptional', maybeOrAbsentE)
 
 -- | The authorisation was given to a business agent and this type represents that business. This type should not be used where a retail customer was authorised.
 -- <https://consumerdatastandardsaustralia.github.io/standards/?swagger#tocCommonCommonSchemas CDR AU v0.1.0>
@@ -53,38 +54,37 @@ organisationFields
   => Organisation -> MapLikeObj ws Json -> MapLikeObj ws Json
 organisationFields o =
   E.atKey' "lastUpdateTime" utcTimeEncoder (_organisationLastUpdateTime o ) .
-  E.atKey' "agentFirstName" (E.maybeOrNull E.text) (_organisationAgentFirstName o ) .
+  maybeOrAbsentE "agentFirstName" E.text (_organisationAgentFirstName o ) .
   E.atKey' "agentLastName" E.text (_organisationAgentLastName o ) .
   E.atKey' "agentRole" E.text (_organisationAgentRole o ) .
   E.atKey' "businessName" E.text (_organisationBusinessName o ) .
-  E.atKey' "legalName" (E.maybeOrNull E.text) (_organisationLegalName o ) .
-  E.atKey' "shortName" (E.maybeOrNull E.text) (_organisationShortName o ) .
-  E.atKey' "abn" (E.maybeOrNull E.text) (_organisationAbn o ) .
-  E.atKey' "acn" (E.maybeOrNull E.text) (_organisationAcn o ) .
-  E.atKey' "isACNRegistered" (E.maybeOrNull E.bool) (_organisationIsACNCRegistered o ) .
-  E.atKey' "industryCode" (E.maybeOrNull E.text) (_organisationIndustryCode o ) .
-  E.atKey' "organisationType" (E.maybeOrNull organisationTypeEncoder) (_organisationOrganisationType o ) .
-  E.atKey' "registeredCountry" (E.maybeOrNull countryAlphaThreeEncoder) (_organisationRegisteredCountry o ) .
-  E.atKey' "establishmentDate" (E.maybeOrNull utcTimeEncoder) (_organisationEstablishmentDate o )
+  maybeOrAbsentE "legalName" E.text (_organisationLegalName o ) .
+  maybeOrAbsentE "shortName" E.text (_organisationShortName o ) .
+  maybeOrAbsentE "abn" E.text (_organisationAbn o ) .
+  maybeOrAbsentE "acn" E.text (_organisationAcn o ) .
+  maybeOrAbsentE "isACNRegistered" E.bool (_organisationIsACNCRegistered o ) .
+  maybeOrAbsentE "industryCode" E.text (_organisationIndustryCode o ) .
+  maybeOrAbsentE "organisationType" organisationTypeEncoder (_organisationOrganisationType o ) .
+  maybeOrAbsentE "registeredCountry" countryAlphaThreeEncoder (_organisationRegisteredCountry o ) .
+  maybeOrAbsentE "establishmentDate" utcTimeEncoder (_organisationEstablishmentDate o )
 
 organisationDecoder :: Monad f => Decoder f Organisation
-organisationDecoder = D.withCursor $ \c -> do
-  o <- D.down c
+organisationDecoder =
   Organisation
-    <$> (D.fromKey "lastUpdateTime" utcTimeDecoder o)
-    <*> (D.fromKey "agentFirstName" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "agentLastName" D.text o)
-    <*> (D.fromKey "agentRole" D.text o)
-    <*> (D.fromKey "businessName" D.text o)
-    <*> (D.fromKey "legalName" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "shortName" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "abn" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "acn" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "isACNRegistered" (D.maybeOrNull D.bool) o)
-    <*> (D.fromKey "industryCode" (D.maybeOrNull D.text) o)
-    <*> (D.fromKey "organisationType" (D.maybeOrNull organisationTypeDecoder) o)
-    <*> (D.fromKey "registeredCountry" (D.maybeOrNull countryAlphaThreeDecoder) o)
-    <*> (D.fromKey "establishmentDate" (D.maybeOrNull utcTimeDecoder) o)
+    <$> D.atKey "lastUpdateTime" utcTimeDecoder
+    <*> atKeyOptional' "agentFirstName" D.text
+    <*> D.atKey "agentLastName" D.text
+    <*> D.atKey "agentRole" D.text
+    <*> D.atKey "businessName" D.text
+    <*> atKeyOptional' "legalName" D.text
+    <*> atKeyOptional' "shortName" D.text
+    <*> atKeyOptional' "abn" D.text
+    <*> atKeyOptional' "acn" D.text
+    <*> atKeyOptional' "isACNRegistered" D.bool
+    <*> atKeyOptional' "industryCode" D.text
+    <*> atKeyOptional' "organisationType" organisationTypeDecoder
+    <*> atKeyOptional' "registeredCountry" countryAlphaThreeDecoder
+    <*> atKeyOptional' "establishmentDate" utcTimeDecoder
 
 -- | List of organisation types.
 data OrganisationType =

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Common/Customer/Data/PhoneNumber.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Common/Customer/Data/PhoneNumber.hs
@@ -17,6 +17,8 @@ import qualified Waargonaut.Decode.Error             as D
 import           Waargonaut.Encode                   (Encoder)
 import qualified Waargonaut.Encode                   as E
 
+import           Waargonaut.Helpers                  (atKeyOptional', maybeOrAbsentE)
+
 -- | PhoneNumber <https://consumerdatastandardsaustralia.github.io/standards/?swagger#schemaphonenumber CDR AU v0.1.0 PhoneNumber >
 data PhoneNumber = PhoneNumber
  { _phoneNumberIsPreferred :: Bool               -- ^ Required to be true for one and only one entry to indicate the preferred phone number
@@ -32,21 +34,21 @@ phoneNumberEncoder :: Applicative f => Encoder f PhoneNumber
 phoneNumberEncoder = E.mapLikeObj $ \pn ->
   E.atKey' "isPreferred" E.bool (_phoneNumberIsPreferred pn) .
   E.atKey' "purpose" phoneNumberPurposeEncoder (_phoneNumberPurpose pn) .
-  E.atKey' "countryCode" (E.maybeOrNull E.text) (_phoneNumberCountryCode pn) .
-  E.atKey' "areaCode" (E.maybeOrNull E.text) (_phoneNumberAreaCode pn) .
+  maybeOrAbsentE "countryCode" E.text (_phoneNumberCountryCode pn) .
+  maybeOrAbsentE "areaCode" E.text (_phoneNumberAreaCode pn) .
   E.atKey' "number" E.text (_phoneNumberNumber pn) .
-  E.atKey' "extension" (E.maybeOrNull E.text) (_phoneNumberExtension pn) .
+  maybeOrAbsentE "extension" E.text (_phoneNumberExtension pn) .
   E.atKey' "fullNumber" E.text (_phoneNumberFullNumber pn)
 
 phoneNumberDecoder :: Monad f => Decoder f PhoneNumber
 phoneNumberDecoder = PhoneNumber
-  <$> (D.atKey "isPreferred" D.bool)
-  <*> (D.atKey "purpose" phoneNumberPurposeDecoder)
-  <*> (D.atKey "countryCode" $ D.maybeOrNull D.text)
-  <*> (D.atKey "areaCode" $ D.maybeOrNull D.text)
-  <*> (D.atKey "number" D.text)
-  <*> (D.atKey "extension" $ D.maybeOrNull D.text)
-  <*> (D.atKey "fullNumber" D.text)
+  <$> D.atKey "isPreferred" D.bool
+  <*> D.atKey "purpose" phoneNumberPurposeDecoder
+  <*> atKeyOptional' "countryCode" D.text
+  <*> atKeyOptional' "areaCode"  D.text
+  <*> D.atKey "number" D.text
+  <*> atKeyOptional' "extension" D.text
+  <*> D.atKey "fullNumber" D.text
 
 
 -- | The purpose of the phone number.

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Data/PhysicalAddress.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Data/PhysicalAddress.hs
@@ -21,6 +21,7 @@ import qualified Waargonaut.Decode.Error    as D
 import           Waargonaut.Encode          (Encoder)
 import qualified Waargonaut.Encode          as E
 
+import           Waargonaut.Helpers         (atKeyOptional', maybeOrAbsentE)
 import Web.ConsumerData.Au.Api.Types.Stub
     (emptyObjDecoder, emptyObjEncoder)
 import Web.ConsumerData.Au.Api.Types.SumTypeHelpers
@@ -109,25 +110,25 @@ data SimpleAddress = SimpleAddress
 
 simpleAddressEncoder :: Applicative f => Encoder f SimpleAddress
 simpleAddressEncoder = E.mapLikeObj $ \p ->
-  E.atKey' "mailingName" (E.maybeOrNull E.text) (_simpleAddressMailingName p) .
+  maybeOrAbsentE "mailingName" E.text (_simpleAddressMailingName p) .
   E.atKey' "addressLine1" E.text (_simpleAddressAddressLine1 p) .
-  E.atKey' "addressLine2" (E.maybeOrNull E.text) (_simpleAddressAddressLine2 p) .
-  E.atKey' "addressLine3" (E.maybeOrNull E.text) (_simpleAddressAddressLine3 p) .
-  E.atKey' "postcode" (E.maybeOrNull E.text) (_simpleAddressPostcode p) .
+  maybeOrAbsentE "addressLine2" E.text (_simpleAddressAddressLine2 p) .
+  maybeOrAbsentE "addressLine3" E.text (_simpleAddressAddressLine3 p) .
+  maybeOrAbsentE "postcode" E.text (_simpleAddressPostcode p) .
   E.atKey' "city" E.text (_simpleAddressCity p) .
   E.atKey' "state" addressStateEncoder (_simpleAddressState p) .
-  E.atKey' "country" (E.maybeOrNull countryAlphaThreeEncoder) (_simpleAddressCountry p)
+  maybeOrAbsentE "country" countryAlphaThreeEncoder (_simpleAddressCountry p)
 
 simpleAddressDecoder :: Monad f => Decoder f SimpleAddress
 simpleAddressDecoder = SimpleAddress
-    <$> (D.atKey "mailingName" $ D.maybeOrNull D.text)
-    <*> (D.atKey "addressLine1" D.text)
-    <*> (D.atKey "addressLine2" $ D.maybeOrNull D.text)
-    <*> (D.atKey "addressLine3" $ D.maybeOrNull D.text)
-    <*> (D.atKey "postcode" $ D.maybeOrNull D.text)
-    <*> (D.atKey "city" D.text)
-    <*> (D.atKey "state" addressStateDecoder)
-    <*> (D.atKey "country" $ D.maybeOrNull countryAlphaThreeDecoder)
+    <$> atKeyOptional' "mailingName" D.text
+    <*> D.atKey "addressLine1" D.text
+    <*> atKeyOptional' "addressLine2" D.text
+    <*> atKeyOptional' "addressLine3" D.text
+    <*> atKeyOptional' "postcode" D.text
+    <*> D.atKey "city" D.text
+    <*> D.atKey "state" addressStateDecoder
+    <*> atKeyOptional' "country" countryAlphaThreeDecoder
 
 -- | @AddressState@ If country is Australia then must be one of the values defined by the <https://www.iso.org/obp/ui/#iso:code:3166:AU ISO 3166:AU> standard.
 data AddressState =

--- a/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Common/CustomerTest/personDetail.json
+++ b/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Common/CustomerTest/personDetail.json
@@ -17,7 +17,6 @@
                 "countryCode": "61",
                 "areaCode": "04",
                 "number": "88145427",
-                "extension": null,
                 "fullNumber": "+61488145427"
             }
         ],


### PR DESCRIPTION
For optional fields, accept absent keys, not just keys with a null value. This also converts decoders to `atKey` style where possible instead of `fromKey` style.