### PR TITLE
Update .dir-locals.el to match project structure.

### DIFF
--- a/consumer-data-au-api-types/src/.dir-locals.el
+++ b/consumer-data-au-api-types/src/.dir-locals.el
@@ -1,5 +1,5 @@
 ((nil . (
-  (dante-target . "test:tasty")
+  (dante-target . "consumer-data-au-api-types:consumer-data-au-api-types")
   (dante-repl-command-line . ("nix-shell" "--run" (concat "cabal new-repl " dante-target " --builddir=dist/dante")))
   (spacemacs/lsp-haskell-nix-shell-args . (list "--args" "hie" "true"))
 )))

--- a/consumer-data-au-api-types/tests/.dir-locals.el
+++ b/consumer-data-au-api-types/tests/.dir-locals.el
@@ -2,4 +2,4 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((haskell-mode
-  (dante-target . "tasty")))
+  (dante-target . "consumer-data-au-api-types:tasty")))

--- a/consumer-data-au-lambdabank/src/.dir-locals.el
+++ b/consumer-data-au-lambdabank/src/.dir-locals.el
@@ -1,5 +1,5 @@
 ((nil . (
-  (dante-target . "consumer-data-au-api-client:consumer-data-au-api-client")
+  (dante-target . "consumer-data-au-lambdabank:consumer-data-au-lambdabank")
   (dante-repl-command-line . ("nix-shell" "--run" (concat "cabal new-repl " dante-target " --builddir=dist/dante")))
   (spacemacs/lsp-haskell-nix-shell-args . (list "--args" "hie" "true"))
 )))

--- a/consumer-data-au-lambdabank/tests/.dir-locals.el
+++ b/consumer-data-au-lambdabank/tests/.dir-locals.el
@@ -1,5 +1,5 @@
 ((nil . (
-  (dante-target . "test:tasty")
+  (dante-target . "consumer-data-au-lambdabank:tasty")
   (dante-repl-command-line . ("nix-shell" "--run" (concat "cabal new-repl " dante-target " --builddir=dist/dante")))
   (spacemacs/lsp-haskell-nix-shell-args . (list "--args" "hie" "true"))
 )))


### PR DESCRIPTION
Now that we're not duplicating dependencies and modules in test targets, we need
separate .dir-locals to make dante happy.