### PR TITLE
Separate cabal.project file for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ install:
   - cat cabal.project || true
   - cat cabal.project.local || true
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="travis.project" --dep -j2 all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="travis.project" --dep -j2 all
   - rm -rf .ghc.environment.* "consumer-data-au-api-client"/dist "consumer-data-au-api-types"/dist "consumer-data-au-lambdabank"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
@@ -69,17 +69,17 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # this builds all libraries and executables (without tests/benchmarks)
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="travis.project" all
 
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="travis.project" all
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} --project-file="travis.project" all; fi
 
   # haddock
-  - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
+  - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} --project-file="travis.project" all; else echo "Skipping haddock generation";fi
 
   # Build without installed constraints for packages in global-db
-  - if $UNCONSTRAINED; then rm -f cabal.project.local; echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks all; else echo "Not building without installed constraints"; fi
+  - if $UNCONSTRAINED; then rm -f cabal.project.local; echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="travis.project" all; else echo "Not building without installed constraints"; fi
 
 # REGENDATA ["cabal.project"]
 # EOF

--- a/cabal.project
+++ b/cabal.project
@@ -7,12 +7,3 @@ with-compiler: ghc-8.4.4
 
 haddock-css: ../haddock.css
 
-source-repository-package
-  type: git
-  location: https://github.com/qfpl/servant-waargonaut.git
-  tag: 89723f630cb3cc4d2dd7544b8e55cba9b9354bde
-
-source-repository-package
-  type: git
-  location: https://github.com/qfpl/waargonaut.git
-  tag: e94dc7c8632a2fbb5605efb21a1d9b4492457da9

--- a/travis.project
+++ b/travis.project
@@ -1,0 +1,18 @@
+packages:
+  consumer-data-au-api-types
+  consumer-data-au-api-client
+  consumer-data-au-lambdabank
+
+with-compiler: ghc-8.4.4
+
+haddock-css: ../haddock.css
+
+source-repository-package
+  type: git
+  location: https://github.com/qfpl/servant-waargonaut.git
+  tag: 89723f630cb3cc4d2dd7544b8e55cba9b9354bde
+
+source-repository-package
+  type: git
+  location: https://github.com/qfpl/waargonaut.git
+  tag: e94dc7c8632a2fbb5605efb21a1d9b4492457da9


### PR DESCRIPTION
This means the git dependencies won't step on our toes when we build with nix.
If you want to build with raw cabal, just add `--project-file=travis.project` to your `cabal` invocations.