### PR TITLE
Proof of concept auth algebra.

### DIFF
--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types.hs
@@ -38,10 +38,12 @@ import Web.ConsumerData.Au.Api.Types.Response              as Response
 
 type CommonRoute r = r :- "common" :> ToServant CommonApi AsApi
 type BankingRoute r = r :- "banking" :> ToServant BankingApi AsApi
+type AuthRoute r = r :- "auth" :> ToServant AuthApi AsApi
 
 data Api r = Api
   { _common  :: CommonRoute r
   , _banking :: BankingRoute r
+  , _auth    :: AuthRoute r
   } deriving (Generic)
 
 common :: Getter (Api r) (CommonRoute r)
@@ -49,6 +51,9 @@ common = to _common
 
 banking :: Getter (Api r) (BankingRoute r)
 banking = to _banking
+
+auth :: Getter (Api r) (AuthRoute r)
+auth = to _auth
 
 api :: Proxy (ToServantApi Api)
 api = genericApi (Proxy :: Proxy Api)

--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Auth/AuthApi.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Auth/AuthApi.hs
@@ -4,31 +4,37 @@
 
 module Web.ConsumerData.Au.Api.Types.Auth.AuthApi where
 
-import Crypto.JWT                          (SignedJWT)
+-- import Crypto.JWT                          (SignedJWT)
+import Data.Text (Text)
 import GHC.Generics                        (Generic)
+-- import Servant.API
+--     ((:>), QueryParam, QueryParam', Required, StdMethod (GET), Strict, Verb, Get, PlainText)
 import Servant.API
-    ((:>), QueryParam, QueryParam', Required, StdMethod (GET), Strict, Verb)
-import Servant.API.ContentTypes.Waargonaut (WaargJSON)
+    ((:>), QueryParam', Required, StdMethod (GET), Strict, Verb, Get, PlainText)
+-- import Servant.API.ContentTypes.Waargonaut (WaargJSON)
 import Servant.API.Generic                 ((:-))
 
-import Web.ConsumerData.Au.Api.Types.Auth.Common
-    (ClientId, IdToken, IdTokenUse (TokenUse), Nonce, RedirectUri,
-    ResponseType, Scopes, State)
+-- import Web.ConsumerData.Au.Api.Types.Auth.Common
+--     (ClientId, IdToken, IdTokenUse (TokenUse), Nonce, RedirectUri,
+--     ResponseType, Scopes, State)
 
 data Foo = Foo
 
 data AuthApi route =
   AuthApi
   {
-    authorise :: route :- "authorise"
-      :> RQP "response_type" ResponseType
-      :> RQP "client_id" ClientId
-      :> RQP "redirect_uri" RedirectUri
-      :> RQP "scope" Scopes
-      :> RQP "request" SignedJWT
-      :> RQP "nonce" Nonce
-      :> QueryParam "state" State
-      :> Get302 '[WaargJSON Foo] (IdToken 'TokenUse)
+    -- authorise :: route :- "authorise"
+    --   :> RQP "response_type" ResponseType
+    --   :> RQP "client_id" ClientId
+    --   :> RQP "redirect_uri" RedirectUri
+    --   :> RQP "scope" Scopes
+    --   :> RQP "request" SignedJWT
+    --   :> RQP "nonce" Nonce
+    --   :> QueryParam "state" State
+    --   :> Get302 '[WaargJSON Foo] (IdToken 'TokenUse)
+
+  inc :: route :- "increment"
+      :> Get '[PlainText] Text
 
   -- , token :: route :- "token"
   --     :> ReqBody '[FormUrlEncoded] TokenRequest

--- a/consumer-data-au-lambdabank/consumer-data-au-lambdabank.cabal
+++ b/consumer-data-au-lambdabank/consumer-data-au-lambdabank.cabal
@@ -14,7 +14,7 @@ tested-with:         GHC == 8.4.4
 
 library
   exposed-modules:
-                     Data.Coproduct
+                     Data.Functor.Coproduct
                    , Web.ConsumerData.Au.LambdaBank.Main
                    , Web.ConsumerData.Au.LambdaBank.Alien.Servant.Server
                    , Web.ConsumerData.Au.LambdaBank.FakeData

--- a/consumer-data-au-lambdabank/consumer-data-au-lambdabank.cabal
+++ b/consumer-data-au-lambdabank/consumer-data-au-lambdabank.cabal
@@ -13,9 +13,13 @@ cabal-version:       >=1.10
 tested-with:         GHC == 8.4.4
 
 library
-  exposed-modules:   Web.ConsumerData.Au.LambdaBank.Main
+  exposed-modules:
+                     Data.Coproduct
+                   , Web.ConsumerData.Au.LambdaBank.Main
                    , Web.ConsumerData.Au.LambdaBank.Alien.Servant.Server
                    , Web.ConsumerData.Au.LambdaBank.FakeData
+                   , Web.ConsumerData.Au.LambdaBank.AuthModel
+                   , Web.ConsumerData.Au.LambdaBank.LambdaModel
                    , Web.ConsumerData.Au.LambdaBank.Model
                    , Web.ConsumerData.Au.LambdaBank.Server
                    , Web.ConsumerData.Au.LambdaBank.Server.Auth
@@ -45,6 +49,7 @@ library
                      , profunctors == 5.*
                      , servant == 0.14.*
                      , servant-server == 0.14.*
+                     , stm == 2.4.*
                      , text == 1.2.*
                      , time >= 1.8 && < 1.10
                      , transformers == 0.5.*

--- a/consumer-data-au-lambdabank/consumer-data-au-lambdabank.nix
+++ b/consumer-data-au-lambdabank/consumer-data-au-lambdabank.nix
@@ -2,7 +2,7 @@
 , consumer-data-au-api-client, consumer-data-au-api-types, country
 , currency-codes, digit, exceptions, free, hedgehog, http-client
 , jose, lens, modern-uri, mtl, profunctors, servant, servant-client
-, servant-server, stdenv, tasty, tasty-discover, tasty-golden
+, servant-server, stdenv, stm, tasty, tasty-discover, tasty-golden
 , tasty-hedgehog, tasty-hunit, text, time, transformers, wai, warp
 }:
 mkDerivation {
@@ -14,8 +14,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson base bytestring consumer-data-au-api-client
     consumer-data-au-api-types country currency-codes digit free jose
-    lens modern-uri mtl profunctors servant servant-server text time
-    transformers wai warp
+    lens modern-uri mtl profunctors servant servant-server stm text
+    time transformers wai warp
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/consumer-data-au-lambdabank/src/Data/Coproduct.hs
+++ b/consumer-data-au-lambdabank/src/Data/Coproduct.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module Data.Coproduct where
+
+data ((f :: * -> *) :+: (g :: * -> *)) e = Inl (f e) | Inr (g e)
+  deriving (Functor)
+infixr 6 :+:
+
+class (Functor f, Functor g) => f :<: g where
+  inj :: f a -> g a
+
+instance Functor f => f :<: f where
+  inj = id
+
+instance {-# OVERLAPPING #-} (Functor f, Functor g) => f :<: (f :+: g) where
+  inj = Inl
+
+instance {-# OVERLAPPABLE #-} (f :<: g, Functor h)  => f :<: (h :+: g) where
+  inj = Inr . inj

--- a/consumer-data-au-lambdabank/src/Data/Functor/Coproduct.hs
+++ b/consumer-data-au-lambdabank/src/Data/Functor/Coproduct.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators         #-}
 
-module Data.Coproduct where
+-- | Taken wholesale from Data types a la carte.
+module Data.Functor.Coproduct where
 
 data ((f :: * -> *) :+: (g :: * -> *)) e = Inl (f e) | Inr (g e)
   deriving (Functor)

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
@@ -46,8 +46,3 @@ runAuthModelF = \case
     counter <- liftIO . fmap succ $ readTVarIO counterVar
     liftIO . atomically $ writeTVar counterVar counter
     pure $ next counter
-
-authProg :: AuthModelM Integer
-authProg = do
-  _ <- incrementCount
-  incrementCount

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module Web.ConsumerData.Au.LambdaBank.AuthModel where
+
+import Control.Concurrent.STM      (atomically)
+import Control.Concurrent.STM.TVar (TVar, readTVarIO, writeTVar)
+import Control.Monad.Free          (MonadFree, liftF)
+import Control.Monad.Free.Church   (F)
+import Control.Monad.IO.Class      (MonadIO, liftIO)
+import Control.Monad.Reader.Class  (MonadReader, ask)
+
+import Data.Coproduct ((:<:), inj)
+
+data AuthModelF next where
+  IncrementCount :: (Integer -> next) -> AuthModelF next
+
+deriving instance Functor AuthModelF
+
+incrementCount ::
+  ( AuthModelF :<: f
+  , MonadFree f m
+  , Functor f
+  )
+  => m Integer
+incrementCount =
+  liftF . inj $ IncrementCount id
+
+type AuthModelM = F AuthModelF
+
+runAuthModelF ::
+  ( MonadIO m
+  , MonadReader (TVar Integer) m
+  )
+  => AuthModelF a
+  -> m a
+runAuthModelF = \case
+  (IncrementCount next) -> do
+    counterVar <- ask
+    counter <- liftIO . fmap succ $ readTVarIO counterVar
+    liftIO . atomically $ writeTVar counterVar counter
+    pure $ next counter
+
+authProg :: AuthModelM Integer
+authProg = do
+  _ <- incrementCount
+  incrementCount

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/AuthModel.hs
@@ -16,7 +16,7 @@ import Control.Monad.Free.Church   (F)
 import Control.Monad.IO.Class      (MonadIO, liftIO)
 import Control.Monad.Reader.Class  (MonadReader, ask)
 
-import Data.Coproduct ((:<:), inj)
+import Data.Functor.Coproduct ((:<:), inj)
 
 data AuthModelF next where
   IncrementCount :: (Integer -> next) -> AuthModelF next

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
@@ -8,7 +8,7 @@
 
 module Web.ConsumerData.Au.LambdaBank.LambdaModel where
 
-import Control.Concurrent.STM.TVar (TVar, newTVarIO)
+import Control.Concurrent.STM.TVar (TVar)
 import Control.Monad.Free.Church   (F, foldF)
 import Control.Monad.IO.Class      (MonadIO)
 import Control.Monad.Reader        (MonadReader, ReaderT, runReaderT)
@@ -37,10 +37,10 @@ type LambdaModelM = F (AuthModelF :+: ModelF)
 
 runLambdaModelM ::
   forall a.
-  LambdaModelM a
+  TVar Integer
+  -> LambdaModelM a
   -> IO a
-runLambdaModelM ma = do
-  tv <- newTVarIO 0
+runLambdaModelM tv ma = do
   let
     na :: ReaderT (TVar Integer) IO a
     na = foldF runLambdaModelF ma

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
@@ -13,7 +13,7 @@ import Control.Monad.Free.Church   (F, foldF)
 import Control.Monad.IO.Class      (MonadIO)
 import Control.Monad.Reader        (MonadReader, ReaderT, runReaderT)
 
-import Data.Coproduct                           ((:+:) (Inl, Inr))
+import Data.Functor.Coproduct                   ((:+:) (Inl, Inr))
 import Web.ConsumerData.Au.LambdaBank.AuthModel (AuthModelF, runAuthModelF)
 import Web.ConsumerData.Au.LambdaBank.Model     (ModelF, runModelF)
 

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module Web.ConsumerData.Au.LambdaBank.LambdaModel where
+
+import Control.Concurrent.STM.TVar (TVar, newTVarIO)
+import Control.Monad.Free.Church   (F, foldF)
+import Control.Monad.IO.Class      (MonadIO)
+import Control.Monad.Reader        (MonadReader, ReaderT, runReaderT)
+
+import Data.Coproduct                           ((:+:) (Inl, Inr))
+import Web.ConsumerData.Au.LambdaBank.AuthModel (AuthModelF, runAuthModelF)
+import Web.ConsumerData.Au.LambdaBank.Model     (ModelF, runModelF)
+
+type RunLambdaModelM a = forall m. (MonadIO m, MonadReader (TVar Integer) m) => m a
+
+class RunLambdaModelF f where
+  runLambdaModelF :: f a -> RunLambdaModelM a
+
+instance (RunLambdaModelF f, RunLambdaModelF g) => RunLambdaModelF (f :+: g) where
+  runLambdaModelF = \case
+    Inl f -> runLambdaModelF f
+    Inr g -> runLambdaModelF g
+
+instance RunLambdaModelF AuthModelF where
+  runLambdaModelF = runAuthModelF
+
+instance RunLambdaModelF ModelF where
+  runLambdaModelF = runModelF
+
+type LambdaModelM = F (AuthModelF :+: ModelF)
+
+runLambdaModelM ::
+  forall a.
+  LambdaModelM a
+  -> IO a
+runLambdaModelM ma = do
+  tv <- newTVarIO 0
+  let
+    na :: ReaderT (TVar Integer) IO a
+    na = foldF runLambdaModelF ma
+  runReaderT na tv

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/LambdaModel.hs
@@ -11,7 +11,7 @@ module Web.ConsumerData.Au.LambdaBank.LambdaModel where
 import Control.Concurrent.STM.TVar (TVar)
 import Control.Monad.Free.Church   (F, foldF)
 import Control.Monad.IO.Class      (MonadIO)
-import Control.Monad.Reader        (MonadReader, ReaderT, runReaderT)
+import Control.Monad.Reader        (MonadReader, runReaderT)
 
 import Data.Functor.Coproduct                   ((:+:) (Inl, Inr))
 import Web.ConsumerData.Au.LambdaBank.AuthModel (AuthModelF, runAuthModelF)
@@ -40,8 +40,5 @@ runLambdaModelM ::
   TVar Integer
   -> LambdaModelM a
   -> IO a
-runLambdaModelM tv ma = do
-  let
-    na :: ReaderT (TVar Integer) IO a
-    na = foldF runLambdaModelF ma
-  runReaderT na tv
+runLambdaModelM tv ma =
+  runReaderT (foldF runLambdaModelF ma) tv

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
@@ -49,7 +49,7 @@ data ModelF next where
 
 deriving instance Functor ModelF
 
-type ModelFree a = forall f m. (ModelF :<: f, MonadFree f m) => m a-- => ModelFree m
+type ModelFree a = forall f m. (ModelF :<: f, MonadFree f m) => m a
 
 getCustomer :: ModelFree CustomerResponse
 getCustomer = liftF . inj $ GetCustomer id

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
@@ -13,7 +13,7 @@ import Web.ConsumerData.Au.Api.Types
 import Data.Text                 (Text)
 import Control.Monad.Free        (MonadFree, liftF)
 
-import Data.Coproduct ((:<:), inj)
+import Data.Functor.Coproduct ((:<:), inj)
 import Web.ConsumerData.Au.LambdaBank.FakeData
 
 data ModelF next where

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Model.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE GADTs              #-}
-{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators      #-}
 
 module Web.ConsumerData.Au.LambdaBank.Model where
 
@@ -10,8 +12,8 @@ import Web.ConsumerData.Au.Api.Types
 
 import Data.Text                 (Text)
 import Control.Monad.Free        (MonadFree, liftF)
-import Control.Monad.Free.Church (F, iterM)
 
+import Data.Coproduct ((:<:), inj)
 import Web.ConsumerData.Au.LambdaBank.FakeData
 
 data ModelF next where
@@ -47,64 +49,65 @@ data ModelF next where
 
 deriving instance Functor ModelF
 
-getCustomer :: MonadFree ModelF m => m CustomerResponse
-getCustomer = liftF $ GetCustomer id
+type ModelFree a = forall f m. (ModelF :<: f, MonadFree f m) => m a-- => ModelFree m
 
-getCustomerDetail :: MonadFree ModelF m => m CustomerDetailResponse
-getCustomerDetail = liftF $ GetCustomerDetail id
+getCustomer :: ModelFree CustomerResponse
+getCustomer = liftF . inj $ GetCustomer id
 
-getAccounts :: MonadFree ModelF m => m Accounts
-getAccounts = liftF $ GetAccounts id
+getCustomerDetail :: ModelFree CustomerDetailResponse
+getCustomerDetail = liftF . inj $ GetCustomerDetail id
 
-getBalancesAll :: MonadFree ModelF m => m AccountBalances
-getBalancesAll = liftF $ GetBalancesAll id
+getAccounts :: ModelFree Accounts
+getAccounts = liftF . inj $ GetAccounts id
 
-getBalancesForAccounts :: MonadFree ModelF m => AccountIds -> m AccountBalances
-getBalancesForAccounts aIds = liftF $ GetBalancesForAccounts aIds id
+getBalancesAll :: ModelFree AccountBalances
+getBalancesAll = liftF . inj $ GetBalancesAll id
 
-getTransactionsAll :: MonadFree ModelF m => m BulkTransactions
-getTransactionsAll = liftF $ GetTransactionsAll id
+getBalancesForAccounts :: AccountIds -> ModelFree AccountBalances
+getBalancesForAccounts aIds = liftF . inj $ GetBalancesForAccounts aIds id
 
-getTransactionsForAccounts :: MonadFree ModelF m => AccountIds -> m BulkTransactions
-getTransactionsForAccounts aIds = liftF $ GetTransactionsForAccounts aIds id
+getTransactionsAll :: ModelFree BulkTransactions
+getTransactionsAll = liftF . inj $ GetTransactionsAll id
 
-getDirectDebitsAll :: MonadFree ModelF m => m DirectDebitAuthorisations
-getDirectDebitsAll = liftF $ GetDirectDebitsAll id
+getTransactionsForAccounts :: AccountIds -> ModelFree BulkTransactions
+getTransactionsForAccounts aIds = liftF . inj $ GetTransactionsForAccounts aIds id
 
-getDirectDebitsForAccounts :: MonadFree ModelF m => AccountIds -> m DirectDebitAuthorisations
-getDirectDebitsForAccounts aIds = liftF $ GetDirectDebitsForAccounts aIds id
+getDirectDebitsAll :: ModelFree DirectDebitAuthorisations
+getDirectDebitsAll = liftF . inj $ GetDirectDebitsAll id
 
-getAccountById :: MonadFree ModelF m => AccountId -> m AccountDetail
-getAccountById accountId = liftF $ GetAccountById accountId id
+getDirectDebitsForAccounts :: AccountIds -> ModelFree DirectDebitAuthorisations
+getDirectDebitsForAccounts aIds = liftF . inj $ GetDirectDebitsForAccounts aIds id
 
-getTransactionsForAccount :: MonadFree ModelF m => AccountId -> m AccountTransactions
-getTransactionsForAccount accountId = liftF $ GetTransactionsForAccount accountId id
+getAccountById :: AccountId -> ModelFree AccountDetail
+getAccountById accountId = liftF . inj $ GetAccountById accountId id
 
-getTransactionDetailForAccountTransaction :: MonadFree ModelF m => AccountId -> TransactionId -> m TransactionsDetail
-getTransactionDetailForAccountTransaction aId xactId = liftF $ GetTransactionDetailForAccountTransaction aId xactId id
+getTransactionsForAccount :: AccountId -> ModelFree AccountTransactions
+getTransactionsForAccount accountId = liftF . inj $ GetTransactionsForAccount accountId id
 
-getDirectDebitsForAccount :: MonadFree ModelF m => AccountId -> m DirectDebitAuthorisations
-getDirectDebitsForAccount accountId = liftF $ GetDirectDebitsForAccount accountId id
+getTransactionDetailForAccountTransaction :: AccountId -> TransactionId -> ModelFree TransactionsDetail
+getTransactionDetailForAccountTransaction aId xactId = liftF . inj $ GetTransactionDetailForAccountTransaction aId xactId id
 
-getPayeesAll :: MonadFree ModelF m => Maybe PayeeType -> Maybe PageNumber -> Maybe PageSize -> m Payees
-getPayeesAll pt pn ps = liftF $ GetPayeesAll pt pn ps id
+getDirectDebitsForAccount :: AccountId -> ModelFree DirectDebitAuthorisations
+getDirectDebitsForAccount accountId = liftF . inj $ GetDirectDebitsForAccount accountId id
 
-getPayeeDetail :: MonadFree ModelF m => PayeeId -> m PayeeDetail
-getPayeeDetail pId = liftF $ GetPayeeDetail pId id
+getPayeesAll :: Maybe PayeeType -> Maybe PageNumber -> Maybe PageSize -> ModelFree Payees
+getPayeesAll pt pn ps = liftF . inj $ GetPayeesAll pt pn ps id
+
+getPayeeDetail :: PayeeId -> ModelFree PayeeDetail
+getPayeeDetail pId = liftF . inj $ GetPayeeDetail pId id
 
 getProductsAll
-  :: MonadFree ModelF m
-  => Maybe ProductEffective
+  :: Maybe ProductEffective
   -> Maybe DateTimeString
   -> Maybe Text
   -> Maybe ProductCategory
   -> Maybe PageNumber
   -> Maybe PageSize
-  -> m Products
-getProductsAll pe dts t pc pn ps = liftF $ GetProductsAll pe dts t pc pn ps id
+  -> ModelFree Products
+getProductsAll pe dts t pc pn ps = liftF . inj $ GetProductsAll pe dts t pc pn ps id
 
-getProductDetail :: MonadFree ModelF m => ProductId -> m ProductDetail
-getProductDetail pId = liftF $ GetProductDetail pId id
+getProductDetail :: ProductId -> ModelFree ProductDetail
+getProductDetail pId = liftF . inj $ GetProductDetail pId id
 
 
 filterBalancesByAccountIds :: AccountIds -> AccountBalances -> AccountBalances
@@ -121,14 +124,12 @@ filterDirectDebitsByAccountIds (AccountIds aIds) (DirectDebitAuthorisations dds)
   DirectDebitAuthorisations $ filter (\dd -> elem (_accountDirectDebitAccountId dd) aIds) dds
 
 
-type ModelM = F ModelF
-
 -- This will have to take some kind of config later and the calls should actually
 -- take proper inputs (like the user id for get customer). But this works well
 -- enough for now.
-runModelM :: Monad m => ModelM a -> m a
-runModelM = iterM $ \case
-  (GetCustomer next) -> next (CustomerPerson testPerson)
+runModelF :: Monad m => ModelF a -> m a
+runModelF m = pure $ case m of
+  (GetCustomer next)       -> next (CustomerPerson testPerson)
   (GetCustomerDetail next) -> next (CustomerDetailPerson testPersonDetail)
   (GetAccounts next) -> next testAccounts
   (GetBalancesAll next) -> next testBalances

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
@@ -43,5 +43,5 @@ app tv lq = genericServeT runLambdaBankM routes
 
 runServer :: Int -> LinkQualifier -> IO ()
 runServer port lq = do
-  tv <- liftIO $ newTVarIO 0
+  tv <- newTVarIO 0
   run port (app tv lq)

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
@@ -12,15 +12,17 @@ that it looks heinous for now!
 
 import Web.ConsumerData.Au.Api.Types
 
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader        (runReaderT)
-import Network.Wai                 (Application)
-import Network.Wai.Handler.Warp    (run)
-import Servant.Server              (Handler)
-import Servant.Server.Generic      (AsServerT)
+import Control.Concurrent.STM.TVar (TVar, newTVarIO)
+import Control.Monad.IO.Class   (liftIO)
+import Control.Monad.Reader     (runReaderT)
+import Network.Wai              (Application)
+import Network.Wai.Handler.Warp (run)
+import Servant.Server           (Handler)
+import Servant.Server.Generic   (AsServerT)
 
 import Web.ConsumerData.Au.LambdaBank.Alien.Servant.Server (genericServeT)
 import Web.ConsumerData.Au.LambdaBank.LambdaModel          (runLambdaModelM)
+import Web.ConsumerData.Au.LambdaBank.Server.Auth          (authServer)
 import Web.ConsumerData.Au.LambdaBank.Server.Banking       (bankingServer)
 import Web.ConsumerData.Au.LambdaBank.Server.Common        (commonServer)
 import Web.ConsumerData.Au.LambdaBank.Server.Internal      (LambdaBankM)
@@ -29,13 +31,17 @@ routes :: Api (AsServerT LambdaBankM)
 routes = Api
   { _common = commonServer
   , _banking = bankingServer
+  , _auth = authServer
   }
 
-app :: LinkQualifier -> Application
-app lq = genericServeT runLambdaBankM routes
+app :: TVar Integer -> LinkQualifier -> Application
+app tv lq = genericServeT runLambdaBankM routes
   where
     runLambdaBankM :: LambdaBankM a -> Handler a
-    runLambdaBankM m = liftIO . runLambdaModelM . runReaderT m $ lq
+    runLambdaBankM m =
+      liftIO . runLambdaModelM tv . runReaderT m $ lq
 
 runServer :: Int -> LinkQualifier -> IO ()
-runServer port lq = run port (app $ lq)
+runServer port lq = do
+  tv <- liftIO $ newTVarIO 0
+  run port (app tv lq)

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server.hs
@@ -12,14 +12,15 @@ that it looks heinous for now!
 
 import Web.ConsumerData.Au.Api.Types
 
-import Control.Monad.Reader     (runReaderT)
-import Network.Wai              (Application)
-import Network.Wai.Handler.Warp (run)
-import Servant.Server           (Handler)
-import Servant.Server.Generic   (AsServerT)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader        (runReaderT)
+import Network.Wai                 (Application)
+import Network.Wai.Handler.Warp    (run)
+import Servant.Server              (Handler)
+import Servant.Server.Generic      (AsServerT)
 
 import Web.ConsumerData.Au.LambdaBank.Alien.Servant.Server (genericServeT)
-import Web.ConsumerData.Au.LambdaBank.Model                (runModelM)
+import Web.ConsumerData.Au.LambdaBank.LambdaModel          (runLambdaModelM)
 import Web.ConsumerData.Au.LambdaBank.Server.Banking       (bankingServer)
 import Web.ConsumerData.Au.LambdaBank.Server.Common        (commonServer)
 import Web.ConsumerData.Au.LambdaBank.Server.Internal      (LambdaBankM)
@@ -34,7 +35,7 @@ app :: LinkQualifier -> Application
 app lq = genericServeT runLambdaBankM routes
   where
     runLambdaBankM :: LambdaBankM a -> Handler a
-    runLambdaBankM m = runModelM . runReaderT m $ lq
+    runLambdaBankM m = liftIO . runLambdaModelM . runReaderT m $ lq
 
 runServer :: Int -> LinkQualifier -> IO ()
 runServer port lq = run port (app $ lq)

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Auth.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Auth.hs
@@ -3,13 +3,13 @@
 module Web.ConsumerData.Au.LambdaBank.Server.Auth where
 
 import Crypto.JWT             (SignedJWT)
-import Data.Text (Text, pack)
+import Data.Text              (Text, pack)
 import Servant.API.Generic    (ToServant)
 import Servant.Server.Generic (AsServerT, genericServerT)
 
 import Web.ConsumerData.Au.Api.Types
-    (AuthApi (..), ClientId, IdToken, Nonce, RedirectUri, ResponseType, Scopes,
-    State, IdTokenUse (TokenUse))
+    (AuthApi (..), ClientId, IdToken, IdTokenUse (TokenUse), Nonce,
+    RedirectUri, ResponseType, Scopes, State)
 import Web.ConsumerData.Au.LambdaBank.AuthModel       (incrementCount)
 import Web.ConsumerData.Au.LambdaBank.Server.Internal (LambdaBankM)
 

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Auth.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Auth.hs
@@ -2,16 +2,22 @@
 
 module Web.ConsumerData.Au.LambdaBank.Server.Auth where
 
-import Crypto.JWT (SignedJWT)
+import Crypto.JWT             (SignedJWT)
+import Data.Text (Text, pack)
 import Servant.API.Generic    (ToServant)
 import Servant.Server.Generic (AsServerT, genericServerT)
 
 import Web.ConsumerData.Au.Api.Types
-import Web.ConsumerData.Au.LambdaBank.Server.Internal         (LambdaBankM)
+    (AuthApi (..), ClientId, IdToken, Nonce, RedirectUri, ResponseType, Scopes,
+    State, IdTokenUse (TokenUse))
+import Web.ConsumerData.Au.LambdaBank.AuthModel       (incrementCount)
+import Web.ConsumerData.Au.LambdaBank.Server.Internal (LambdaBankM)
 
 authServer :: ToServant AuthApi (AsServerT LambdaBankM)
 authServer = genericServerT AuthApi
-  { authorise = authoriseServer }
+  { -- authorise = authoriseServer
+    inc = incServer
+  }
 
 authoriseServer ::
   ResponseType
@@ -24,3 +30,7 @@ authoriseServer ::
   -> LambdaBankM (IdToken 'TokenUse)
 authoriseServer =
   error "TODO: implement authorise server"
+
+incServer ::
+  LambdaBankM Text
+incServer = pack . show <$> incrementCount

--- a/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Internal.hs
+++ b/consumer-data-au-lambdabank/src/Web/ConsumerData/Au/LambdaBank/Server/Internal.hs
@@ -6,9 +6,9 @@ import Web.ConsumerData.Au.Api.Types
     (LinkQualifier, PaginatedResponse, Paginator, StandardResponse,
     mkPaginatedResponse, mkStandardResponse)
 
-import Web.ConsumerData.Au.LambdaBank.Model
+import Web.ConsumerData.Au.LambdaBank.LambdaModel (LambdaModelM)
 
-type LambdaBankM = ReaderT LinkQualifier ModelM
+type LambdaBankM = ReaderT LinkQualifier LambdaModelM
 
 bankStandardResponse :: a -> Link -> LambdaBankM (StandardResponse a)
 bankStandardResponse a l = asks $ \lq -> mkStandardResponse a lq l


### PR DESCRIPTION
Wire a dummy auth algebra together with the existing bank algebra using the machinery from [Data types a la carte](http://dx.doi.org/10.1017/S0956796808006758).

This PR is to get feedback on the approach before progressing to an actual implementation of auth. Currently the auth API is limited to incrementing an `Integer` stored in a `TVar`. Given the auth implementation is intended for testing only, it will likely keep its state in some data structure using STM, so this PoC is pretty representative.

@benkolera, please check the changes to `Model.hs` in case they make you sad.