### PR TITLE
Bring AuthorisationRequest closer to spec.

### DIFF
--- a/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Auth/Common/Common.hs
+++ b/consumer-data-au-api-types/src/Web/ConsumerData/Au/Api/Types/Auth/Common/Common.hs
@@ -21,6 +21,7 @@ module Web.ConsumerData.Au.Api.Types.Auth.Common.Common
   , Acr (..)
   , AuthUri
   , Claim (..)
+  , ConsentId (..)
   , FapiPermittedAlg
   , getFapiPermittedAlg
   , _FapiPermittedAlg
@@ -110,6 +111,12 @@ newtype State =
 newtype Nonce =
   Nonce {getNonce :: Text}
   deriving (Generic, ToJSON, FromJSON, Show, Eq)
+
+-- TODO ajmcmiddlin: this should probably be a UUID. Waiting on consent spec.
+-- | Identifies a consent object.
+newtype ConsentId =
+  ConsentId Text
+  deriving (Eq, Show, FromJSON, ToJSON)
 
 --TODO create error types
 newtype ErrorCode = ErrorCode Text

--- a/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/Gens.hs
+++ b/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/Gens.hs
@@ -39,20 +39,21 @@ genIdTokenClaims ::
   => n IdTokenClaims
 genIdTokenClaims =
   let
-    genSub ::
-      n (Claim TokenSubject)
     genSub =
       (\a -> Claim [a] False) . TokenSubject <$> Gen.text (Range.linear 1 5) Gen.alphaNum
-    gens :: n [DSum IdTokenKey Claim]
     gens =
       sequence
       [
         (IdTokenSub :=>) <$> genSub
-      -- , IdTokenSub
       ]
+    mostOfAnIdtoken =
+      IdToken
+        Nothing
+        Nothing
+        (Claim [Acr "foo"] True)
+        (Claim [ConsentId "fake consent id"] True)
   in
-    IdToken Nothing Nothing (Claim [Acr "foo"] True) (Claim [ConsentId "fake consent id"] True) <$> (DM.fromList <$> gens)
-      -- DM.traverseWithKey (const (fmap pure)) (DM.fromList <$> gens)
+    mostOfAnIdtoken <$> (DM.fromList <$> gens)
 
 genClaims ::
   MonadGen n

--- a/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/Gens.hs
+++ b/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/Gens.hs
@@ -28,7 +28,7 @@ import           Text.URI.Gens
 import           Web.ConsumerData.Au.Api.Types.Auth.AuthorisationRequest
     (Claims (Claims))
 import           Web.ConsumerData.Au.Api.Types.Auth.Common.Common
-    (Acr (Acr), Claim (Claim), HttpsUrl, TokenSubject (..), mkHttpsUrl)
+    (Acr (Acr), Claim (Claim), HttpsUrl, TokenSubject (..), mkHttpsUrl, ConsentId (..))
 import           Web.ConsumerData.Au.Api.Types.Auth.Common.IdToken
     (IdToken (IdToken), IdTokenClaims, IdTokenKey (..))
 import           Web.ConsumerData.Au.Api.Types.Auth.Error
@@ -51,7 +51,7 @@ genIdTokenClaims =
       -- , IdTokenSub
       ]
   in
-    IdToken Nothing Nothing (Claim [Acr "foo"] True) <$> (DM.fromList <$> gens)
+    IdToken Nothing Nothing (Claim [Acr "foo"] True) (Claim [ConsentId "fake consent id"] True) <$> (DM.fromList <$> gens)
       -- DM.traverseWithKey (const (fmap pure)) (DM.fromList <$> gens)
 
 genClaims ::

--- a/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/RequestTest.hs
+++ b/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/RequestTest.hs
@@ -42,7 +42,7 @@ import qualified Hedgehog.Range             as Range
 import           Test.Tasty                 (TestTree)
 import           Test.Tasty.Hedgehog        (testProperty)
 
-import AesonGolden (aesonGolden)
+import AesonGolden                             (aesonGolden)
 import Text.URI.Gens                           (genUri)
 import Web.ConsumerData.Au.Api.Types.Auth.Gens (genClaims, genJWK)
 
@@ -50,8 +50,8 @@ import Web.ConsumerData.Au.Api.Types.Auth.AuthorisationRequest
     (AuthorisationRequest (AuthorisationRequest), Claims (Claims),
     authRequestToJwt, jwtToAuthRequest)
 import Web.ConsumerData.Au.Api.Types.Auth.Common
-    (Acr (Acr), Claim (Claim), ClientId (ClientId), IdToken (IdToken),
-    IdTokenClaims, IdTokenKey (IdTokenSub), Nonce (Nonce),
+    (Acr (Acr), Claim (Claim), ClientId (ClientId), ConsentId (..),
+    IdToken (IdToken), IdTokenClaims, IdTokenKey (IdTokenSub), Nonce (Nonce),
     Prompt (SelectAccount), RedirectUri (RedirectUri),
     ResponseType (CodeIdToken), Scope (..), State (..), TokenSubject (..),
     mkScopes)
@@ -187,8 +187,9 @@ goldenIdToken ::
 goldenIdToken =
   let
     acrClaim = Claim [Acr "urn:cds.au:cdr:3"] True
+    consentClaim = Claim [ConsentId "fake consent id"] True
     claimsMap = DM.fromList
       [ IdTokenSub :=> Claim [TokenSubject "u12345"] False
       ]
   in
-    IdToken Nothing Nothing acrClaim claimsMap
+    IdToken Nothing Nothing acrClaim consentClaim claimsMap

--- a/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/compact-authorisation-request.golden
+++ b/consumer-data-au-api-types/tests/Web/ConsumerData/Au/Api/Types/Auth/compact-authorisation-request.golden
@@ -18,10 +18,15 @@
                         "urn:cds.au:cdr:3"
                     ],
                     "essential": true
+                },
+                "cdr_consent_id": {
+                    "values": [
+                        "fake consent id"
+                    ],
+                    "essential": true
                 }
             }
         },
-        "iss": "functionalfinance.io",
         "response_type": "code id_token",
         "scope": "openid",
         "aud": "https://lambdabank.io",


### PR DESCRIPTION
Updates the `AuthorisationRequest` type to more closely match the spec. There are likely some other changes to be made that I haven't noticed yet. The two big ones here are:

1. Remove the `iss` claim in the request object.
2. Add `cdr_consent_id` as an essential claim in the ID token.