### PR TITLE
Update types.nix with dependency on nat.

### DIFF
--- a/consumer-data-au-api-types/consumer-data-au-api-types.nix
+++ b/consumer-data-au-api-types/consumer-data-au-api-types.nix
@@ -26,7 +26,7 @@ mkDerivation {
   testHaskellDepends = [
     aeson aeson-diff aeson-pretty attoparsec base bytestring containers
     country currency-codes dependent-map dependent-sum digit exceptions
-    hedgehog http-client jose lens modern-uri mtl network-uri
+    hedgehog http-client jose lens modern-uri mtl nat network-uri
     profunctors servant servant-client servant-server
     servant-waargonaut tagged tasty tasty-discover tasty-golden
     tasty-hedgehog tasty-hunit text time transformers waargonaut wai


### PR DESCRIPTION
Apparently we've been depending on this for a while in our cabal file, but
haven't updated the nix derivation. Guessing it's a transitive dep of something
else?